### PR TITLE
Set the 'fl' param.

### DIFF
--- a/islandora_solr_views_query.inc
+++ b/islandora_solr_views_query.inc
@@ -161,7 +161,8 @@ class islandora_solr_views_query extends views_plugin_query {
 
       // Add query (defaults to *:*).
       $islandora_solr_query->buildQuery($query, $params);
-
+      // Need to add the fl in manually as buildQuery does not account for it.
+      $islandora_solr_query->solrParams['fl'] = $params['fl'];
       // Add solr limit.
       $islandora_solr_query->solrLimit = $params['rows'];
       // Add solr start.


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1992

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
Originally broken in https://github.com/Islandora/islandora_solr_views/pull/18/files (I blame past Jordan)

# What does this Pull Request do?
Sets the 'fl' parameter when we construct a query to populate a Solr view so we don't needlessly grab all fields.

# What's new?
The 'fl' parameters being set in the view are actually being used.

# How should this be tested?
Create a view with fields.
Enable Solr debug from admin/islandora/search/islandora_solr/settings.
When debuging/viewing the view note that the fl parameter is now present in the URL where it wasn't formerly.

# Additional Notes:
This likely leads a discussion as to if we should do field filtering before querying Solr as opposed to post processing in PHP where the memory gets eaten.

# Interested parties
@Islandora/7-x-1-x-committers
