### PR TITLE
Prevent PIDs being rendered as Port numbers

### DIFF
--- a/handlers/islandora_solr_views_handler_field.inc
+++ b/handlers/islandora_solr_views_handler_field.inc
@@ -75,11 +75,10 @@ class islandora_solr_views_handler_field extends views_handler_field {
    * Data should be made XSS safe prior to calling this function.
    */
   function render_link($data, $values) {
-
     if (!empty($this->options['link_to_object']) && !empty($this->additional_fields['PID'])) {
       if ($data !== NULL && $data !== '') {
         $this->options['alter']['make_link'] = TRUE;
-        $this->options['alter']['path'] = 'islandora/object/' . $this->get_value($values, 'PID');
+        $this->options['alter']['path'] = 'islandora/object/' . urlencode($this->get_value($values, 'PID'));
       }
       else {
         $this->options['alter']['make_link'] = FALSE;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1994

# What does this Pull Request do?
Similar to [ISLANDORA-1982](https://github.com/Islandora-Labs/islandora_ip_embargo/pull/28), PIDs are being treated as Port numbers and any PID value over 65535 isn't getting rendered as a link. This is a simple one liner change that ensures the PID portion of the path is encoded as a URL.

**Note: this affects PID values from 65536 to 99999.**

# What's new?
* `urlencode` the PID portion of the path.

# How should this be tested?
Import the solr view I created to demonstrate this bug: [gist](https://gist.github.com/BrandonMorr/f07c99da30b23d85d9eb940df389cc92)

**Or if you're more DIY:**
* Create a test view using Solr fields.
* Ensure to display PID and make sure the `Link field to object` option is enabled.
* For convenience sake, you may want add a filter to only show collection objects.
* Once your view is setup, create a collection with the PID of `something:65535` and `something:65536`.
* Go to your custom view (if using the exported view the path is /solr-view-test) and you'll notice that something:65536 is not rendered as a link.

# Interested parties
@Islandora/7-x-1-x-committers
