### PR TITLE
ISLANDORA-2054: fix more than one field in SORT CRITERIA of a Views

### DIFF
--- a/islandora_solr_views_query.inc
+++ b/islandora_solr_views_query.inc
@@ -131,8 +131,9 @@ class islandora_solr_views_query extends views_plugin_query {
         module_load_include('inc', 'islandora_solr', 'includes/utilities');
         // Populate sorting parameters.
         foreach ($this->orderby as $field => $order) {
-          $params['sort'][] = islandora_solr_lesser_escape($field) . ' ' . $order;
+          $sortFields[] = islandora_solr_lesser_escape($field) . ' ' . $order;
         }
+        $params['sort'][] = implode(",",$sortFields);
       }
 
       // Set query.

--- a/islandora_solr_views_query.inc
+++ b/islandora_solr_views_query.inc
@@ -133,7 +133,7 @@ class islandora_solr_views_query extends views_plugin_query {
         foreach ($this->orderby as $field => $order) {
           $sortFields[] = islandora_solr_lesser_escape($field) . ' ' . $order;
         }
-        $params['sort'][] = implode(",",$sortFields);
+        $params['sort'][] = implode(",", $sortFields);
       }
 
       // Set query.


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2054](https://jira.duraspace.org/browse/ISLANDORA-2054)

* Other Relevant Links: https://groups.google.com/forum/#!topic/islandora/AXH0wm27kH0

# What does this Pull Request do?

When more than one field in SORT CRITERIA of a Views, the query string is wrong:
... &sort=dc.date_dt+asc*&*sort=fgs_label_s+asc& ...
instead of
... &sort=dc.date_dt+asc*,*fgs_label_s+asc& ...

# What's new?
No new features

# How should this be tested?

Build a views with more then one field in SORT CRITERIA.

# Additional Notes:
No additional information.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
