### PR TITLE
ISLANDORA-2141 Don't double-encode link to object.

### DIFF
--- a/handlers/islandora_solr_views_handler_field.inc
+++ b/handlers/islandora_solr_views_handler_field.inc
@@ -78,7 +78,7 @@ class islandora_solr_views_handler_field extends views_handler_field {
     if (!empty($this->options['link_to_object']) && !empty($this->additional_fields['PID'])) {
       if ($data !== NULL && $data !== '') {
         $this->options['alter']['make_link'] = TRUE;
-        $this->options['alter']['path'] = 'islandora/object/' . urlencode($this->get_value($values, 'PID'));
+        $this->options['alter']['path'] = 'islandora/object/' . $this->get_value($values, 'PID' ) . '#view';
       }
       else {
         $this->options['alter']['make_link'] = FALSE;

--- a/handlers/islandora_solr_views_handler_field.inc
+++ b/handlers/islandora_solr_views_handler_field.inc
@@ -79,7 +79,8 @@ class islandora_solr_views_handler_field extends views_handler_field {
       if ($data !== NULL && $data !== '') {
         $this->options['alter']['make_link'] = TRUE;
         $pid = $this->get_value($values, 'PID');
-        $shortpid = explode(':', $pid)[1];
+        $shortpid = explode(':', $pid);
+        $shortpid = $shortpid[1];
         if (is_numeric($shortpid) and ((65536 <= $shortpid) and ($shortpid <= 99999))) {
           $this->options['alter']['path'] = 'islandora/object/' . $pid . '#_';
         }

--- a/handlers/islandora_solr_views_handler_field.inc
+++ b/handlers/islandora_solr_views_handler_field.inc
@@ -78,7 +78,14 @@ class islandora_solr_views_handler_field extends views_handler_field {
     if (!empty($this->options['link_to_object']) && !empty($this->additional_fields['PID'])) {
       if ($data !== NULL && $data !== '') {
         $this->options['alter']['make_link'] = TRUE;
-        $this->options['alter']['path'] = 'islandora/object/' . $this->get_value($values, 'PID' ) . '#view';
+        $pid = $this->get_value($values, 'PID');
+        $shortpid = explode(':', $pid)[1];
+        if (is_numeric($shortpid) and ((65536 <= $shortpid) and ($shortpid <= 99999))) {
+          $this->options['alter']['path'] = 'islandora/object/' . $pid . '#_';
+        }
+        else {
+          $this->options['alter']['path'] = 'islandora/object/' . $pid;
+        }
       }
       else {
         $this->options['alter']['make_link'] = FALSE;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2141
Actually re-fixes the problem from https://jira.duraspace.org/browse/ISLANDORA-1994

# What does this Pull Request do?

Changes how we solve the problem of parse_url failing on pids above namespace:65535, because the previous fix (urlencode()) caused unintended consequences. The final link was double-encoded (namespace%253A65536) and while Drupal still rendered the right object, other stuff broke:
- Usage Stats views (that appear on the collection management page) no longer showed up
- contextual views (which rely on the PID from the URL) no longer worked. 

# What's new?

Don't double-encode; add a meaningless fragment to the url instead. (this tricks parse_url, which is the thing that's really at fault...) 

# How should this be tested?

Create an object with a PID of namespace:65536 or greater. (this is easily done by creating a collection; the collection form lets you assign a PID)
Create a view, with a field that "links to object" and shows this object.

Before the PR: the link renders, and includes %253A in place of colon (:) 
After the PR: the link renders, and includes #view at the end.

To test with Usage Stats
- enable usage stats and make sure you have an object with some stats available.
- get to that object from a "link to object" field in a solr view
Before this PR: the collection usage stats table doesn't show up
After this PR: the collection usage stats table shows up.


# Additional Notes:

* Does this change require documentation to be updated? **Nope**
* Does this change add any new dependencies? **Nope**
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  **Nope**
* Could this change impact execution of existing code? **Maybe!? Hopefully less than the previous solution?**

# Interested parties
@Islandora/7-x-1-x-committers and @bondjimbond 
