### PR TITLE
allow space around the glue

### DIFF
--- a/handlers/islandora_solr_views_handler_filter.inc
+++ b/handlers/islandora_solr_views_handler_filter.inc
@@ -22,7 +22,7 @@ class islandora_solr_views_handler_filter extends views_handler_filter {
         $values = array_filter($value);
         // Ensure that some values have been selected.
         if (!empty($values)) {
-          $this->query->add_filter($fieldname, '(' . implode('OR', $values) . ')', $this->options['group'], $exclude);
+          $this->query->add_filter($fieldname, '(' . implode(' OR ', $values) . ')', $this->options['group'], $exclude);
         }
         return;
       }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2481

# What does this Pull Request do?

Adds space around the glue text for the filter string

# How should this be tested?

I was testing this as I am extending this module with https://github.com/whikloj/islandora_solr_views_select

Not sure it is possible to hit this location normally. But you can see you can have an array, and imploding an array of any values with that glue gives you a single very long word instead of multiple separate ones.

ie.
```
$values = array('bob', 'mary', doug', 'jane');
$filter_string = '(' . implode('OR', $values) . ')';
echo $filter_string; "(bobORmaryORdougORjane)"
```

# Additional Notes:

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? 
  **no**
* Does this change add any new dependencies?
  **no**
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
  **no**
* Could this change impact execution of existing code?
   ...maybe if you have also extended this filter?

# Interested parties
@Islandora/7-x-1-x-committers
